### PR TITLE
Make client_name and client_phone optional in InsertOrderDTO

### DIFF
--- a/src/dtos/order/request.dto.ts
+++ b/src/dtos/order/request.dto.ts
@@ -34,11 +34,11 @@ class PaymentDTO {
 
 export class InsertOrderDTO {
   @IsString()
-  @IsNotEmpty()
+  @IsOptional()
   client_name: string
 
   @IsString()
-  @IsNotEmpty()
+  @IsOptional()
   client_phone: string
 
   @IsOptional()
@@ -50,10 +50,11 @@ export class InsertOrderDTO {
   @Type(() => OrderItemDTO)
   items: OrderItemDTO[]
 
+  @IsOptional() // ✅ Pagar despues
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => PaymentDTO)
-  payments: PaymentDTO[]
+  payments?: PaymentDTO[]
 }
 
 export class UpdateOrderDTO {


### PR DESCRIPTION
Refactor the InsertOrderDTO to make client_name and client_phone optional, allowing for more flexible order creation.